### PR TITLE
Feature/ari 53 go logging

### DIFF
--- a/slackbot/Dockerfile
+++ b/slackbot/Dockerfile
@@ -3,7 +3,7 @@
 # STAGE 1 build Golang executable binary
 ############################
 
-FROM golang:1.10-alpine AS builder
+FROM golang:1.12.1-alpine AS builder
 ENV bin_dir=/go/bin/
 RUN apk update && apk add --no-cache openssl openssh curl bash git openssh libcurl
 WORKDIR $GOPATH/src/github.com/buildit/slackbot
@@ -45,7 +45,7 @@ RUN azcopy \
 # STAGE 3 Build small image with only binary
 ############################
 
-FROM golang:1.10-alpine
+FROM golang:1.12.1-alpine
 ENV bin_dir=/go/bin/
 COPY --from=builder ${bin_dir}/bot-server.sh /go/bin/bot-server.sh
 RUN cd ${bin_dir} && ls

--- a/slackbot/Dockerfile
+++ b/slackbot/Dockerfile
@@ -1,9 +1,10 @@
+FROM golang:1.12.1-alpine AS golang
 
 ############################
 # STAGE 1 build Golang executable binary
 ############################
 
-FROM golang:1.12.1-alpine AS builder
+FROM golang AS builder
 ENV bin_dir=/go/bin/
 RUN apk update && apk add --no-cache openssl openssh curl bash git openssh libcurl
 WORKDIR $GOPATH/src/github.com/buildit/slackbot
@@ -19,7 +20,7 @@ RUN go test -v ./... | go-junit-report > /go/TestResults/TestReport.xml
 # STAGE 2 Upload test results to Azure
 ############################
 
-FROM microsoft/dotnet:latest as tester
+FROM microsoft/dotnet:latest AS tester
 
 ARG STORAGE_ACCT_URL
 ARG STORAGE_ACCT_KEY
@@ -45,7 +46,7 @@ RUN azcopy \
 # STAGE 3 Build small image with only binary
 ############################
 
-FROM golang:1.12.1-alpine
+FROM golang AS final
 ENV bin_dir=/go/bin/
 COPY --from=builder ${bin_dir}/bot-server.sh /go/bin/bot-server.sh
 RUN cd ${bin_dir} && ls

--- a/slackbot/README.md
+++ b/slackbot/README.md
@@ -2,7 +2,7 @@ Build, Test, and Run Slackbot Container
 
 
     cd <workspace>/slackbot  
-	docker build -t slackbot:latest .  
+	DOCKER_BUILDKIT=1 docker build --target=final -t slackbot:latest .  
 	docker run -d -p 4390:4390 -e SLACKBOT_OAUTHTOKEN="<oauthtoken>" -e SLACKBOT_VERIFICATIONTOKEN="<verificationtoken>" slackbot:latest  
 
   

--- a/slackbot/cmd/bot-server/main.go
+++ b/slackbot/cmd/bot-server/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"github.com/buildit/slackbot/pkg/database"
 	"github.com/buildit/slackbot/pkg/service"
 	"github.com/gorilla/mux"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 )
 
@@ -17,14 +16,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer database.CloseDB()
 
 	router := mux.NewRouter()
 	router.HandleFunc("/", service.ListenAndServeHome)
 	router.HandleFunc("/events", service.ListenAndServeEvents).Methods("POST")
 	router.HandleFunc("/slash", service.ListenAndServeSlash).Methods("POST")
 	router.HandleFunc("/interactions", service.ListenAndServeInteractions).Methods("POST")
-	fmt.Println("[INFO] Server listening")
+	log.Println("Server listening")
 	log.Fatal(http.ListenAndServe(":80", router))
-	defer database.CloseDB()
 
 }

--- a/slackbot/cmd/bot-server/main.go
+++ b/slackbot/cmd/bot-server/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/buildit/slackbot/pkg/bot-server"
 	"github.com/buildit/slackbot/pkg/database"
+	"github.com/buildit/slackbot/pkg/service"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -19,10 +19,10 @@ func main() {
 	}
 
 	router := mux.NewRouter()
-	router.HandleFunc("/", bot_server.ListenAndServeHome)
-	router.HandleFunc("/events", bot_server.ListenAndServeEvents).Methods("POST")
-	router.HandleFunc("/slash", bot_server.ListenAndServeSlash).Methods("POST")
-	router.HandleFunc("/interactions", bot_server.ListenAndServeInteractions).Methods("POST")
+	router.HandleFunc("/", service.ListenAndServeHome)
+	router.HandleFunc("/events", service.ListenAndServeEvents).Methods("POST")
+	router.HandleFunc("/slash", service.ListenAndServeSlash).Methods("POST")
+	router.HandleFunc("/interactions", service.ListenAndServeInteractions).Methods("POST")
 	fmt.Println("[INFO] Server listening")
 	log.Fatal(http.ListenAndServe(":80", router))
 	defer database.CloseDB()

--- a/slackbot/pkg/config/config.go
+++ b/slackbot/pkg/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"github.com/kelseyhightower/envconfig"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // Config contains environment variables used to configure the app

--- a/slackbot/pkg/database/database.go
+++ b/slackbot/pkg/database/database.go
@@ -3,8 +3,8 @@ package database
 import (
 	"fmt"
 	"github.com/buildit/slackbot/pkg/config"
+	log "github.com/sirupsen/logrus"
 	"go.etcd.io/bbolt"
-	"log"
 )
 
 var (

--- a/slackbot/pkg/poll/db.go
+++ b/slackbot/pkg/poll/db.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/buildit/slackbot/pkg/config"
+	log "github.com/sirupsen/logrus"
 	"go.etcd.io/bbolt"
-	"log"
 )
 
 var pollBucket = []byte(config.Env.PollBucket)
@@ -23,7 +23,7 @@ func AddPoll(db *bbolt.DB, id string, poll Poll) error {
 		}
 		return nil
 	})
-	log.Printf("Successfully persisted Poll ID=%s to Bolt\n", id)
+	log.Printf("Successfully persisted Poll ID=%s to Bolt", id)
 	return err
 }
 func DeletePoll(db *bbolt.DB, id string) error {
@@ -36,7 +36,7 @@ func DeletePoll(db *bbolt.DB, id string) error {
 		}
 		return nil
 	})
-	log.Printf("Successfully Deleted Poll ID=%s from Bolt\n", id)
+	log.Printf("Successfully Deleted Poll ID=%s from Bolt", id)
 	return err
 }
 
@@ -53,6 +53,6 @@ func GetPoll(db *bbolt.DB, id string) (Poll, error) {
 
 		return nil
 	})
-	log.Printf("Successfully retrieved Poll ID=%s from Bolt\n", id)
+	log.Printf("Successfully retrieved Poll ID=%s from Bolt", id)
 	return retrievedPoll, err
 }

--- a/slackbot/pkg/poll/poll.go
+++ b/slackbot/pkg/poll/poll.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/buildit/slackbot/pkg/util"
 	"github.com/nlopes/slack"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math/rand"
 	"sort"
 	"strconv"

--- a/slackbot/pkg/service/service.go
+++ b/slackbot/pkg/service/service.go
@@ -8,8 +8,8 @@ import (
 	"github.com/buildit/slackbot/pkg/poll"
 	"github.com/nlopes/slack"
 	"github.com/nlopes/slack/slackevents"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -48,14 +48,14 @@ func ListenAndServeSlash(w http.ResponseWriter, r *http.Request) {
 		params := &slack.Msg{Text: s.Text}
 		normalizedParams := strings.Map(poll.Normalize, params.Text)
 		slicedParams := poll.SplitParameters(normalizedParams)
-		log.Printf("Poll Submission detected with Message Paramters:%q\n", slicedParams)
+		log.Printf("Poll Submission detected with Message Paramters:%q", slicedParams)
 
 		if len(slicedParams) < 1 {
-			log.Printf("[ERROR] No Topic Provided for the submitted poll \n")
+			log.Error("No Topic Provided for the submitted poll")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 		if len(slicedParams) > 10 {
-			log.Printf("[ERROR] Polling only supports up to 10 options \n")
+			log.Error("Polling only supports up to 10 options")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 		slackPoll = poll.CreatePoll(slicedParams)
@@ -65,45 +65,45 @@ func ListenAndServeSlash(w http.ResponseWriter, r *http.Request) {
 		channelID, timestamp, err := api.PostMessage(s.ChannelID, slack.MsgOptionText(slackPoll.Title, false), slack.MsgOptionAttachments(slackPoll.Attachment))
 
 		if err != nil {
-			log.Printf("%s\n", err)
+			log.Printf("%s", err)
 			return
 		}
-		log.Printf("Poll '%s' successfully created on channel %s at %s \n", slackPoll.Identifier, channelID, timestamp)
+		log.Printf("Poll '%s' successfully created on channel %s at %s", slackPoll.Identifier, channelID, timestamp)
 	}
 
 }
 func ListenAndServeInteractions(w http.ResponseWriter, r *http.Request) {
 	buf, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("[ERROR] Failed to read request body: %s", err)
+		log.Error("Failed to read request body: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 
 	jsonStr, err := url.QueryUnescape(string(buf)[8:])
 	if err != nil {
-		log.Printf("[ERROR] Failed to unescape request body: %s", err)
+		log.Error("Failed to unescape request body: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	var message slack.InteractionCallback
 	if err := json.Unmarshal([]byte(jsonStr), &message); err != nil {
-		log.Printf("[ERROR] Failed to decode json message from slack: %s", jsonStr)
+		log.Error("Failed to decode json message from slack: %s", jsonStr)
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	// Only accept message from slack with valid token
 	if message.Token != config.Env.VerificationToken {
-		log.Printf("[ERROR] Invalid token: %s", message.Token)
+		log.Error("Invalid token: %s", message.Token)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 
-	log.Printf("Received Message: %s \n", jsonStr)
+	log.Printf("Received Message: %s", jsonStr)
 
 	callbackType := ""
 	id := message.CallbackID
 	if strings.Contains(id, "poll") {
 		callbackType = "poll"
 	}
-	log.Printf("CallbackType: %s \n", callbackType)
+	log.Printf("CallbackType: %s", callbackType)
 
 	switch callbackType {
 	case "poll":
@@ -117,13 +117,13 @@ func ListenAndServeInteractions(w http.ResponseWriter, r *http.Request) {
 
 			channelID, timestamp, text, err := api.UpdateMessage(message.Channel.ID, message.MessageTs, slack.MsgOptionText(slackPoll.Title, false), slack.MsgOptionAttachments(slackPoll.Attachment))
 			if err != nil {
-				log.Printf("%s\n", err)
+				log.Printf("%s", err)
 				return
 			}
 
 			poll.DeletePoll(database.DBCon, id)
 
-			log.Printf("Poll '%s' deleted on channel %s at %s. Reponse with text %s \n", slackPoll.Identifier, channelID, timestamp, text)
+			log.Printf("Poll '%s' deleted on channel %s at %s. Reponse with text %s", slackPoll.Identifier, channelID, timestamp, text)
 		} else { //It's a vote calllback
 			slackPoll = poll.AddVote(slackPoll, message.User.Name, message.Actions[0].Value)
 		}
@@ -137,10 +137,10 @@ func ListenAndServeInteractions(w http.ResponseWriter, r *http.Request) {
 		//Update the poll in Slack
 		channelID, timestamp, text, err := api.UpdateMessage(message.Channel.ID, message.MessageTs, slack.MsgOptionText(slackPoll.Attachment.Title, false), slack.MsgOptionAttachments(slackPoll.Attachment))
 		if err != nil {
-			log.Printf("%s\n", err)
+			log.Printf("%s", err)
 			return
 		}
-		log.Printf("Poll '%s' successfully sent to channel %s at %s. Reponse with text %s \n", slackPoll.Identifier, channelID, timestamp, text)
+		log.Printf("Poll '%s' successfully sent to channel %s at %s. Reponse with text %s", slackPoll.Identifier, channelID, timestamp, text)
 	}
 
 }

--- a/slackbot/pkg/service/service.go
+++ b/slackbot/pkg/service/service.go
@@ -1,4 +1,4 @@
-package bot_server
+package service
 
 import (
 	"bytes"


### PR DESCRIPTION
ultimately just replacing the std log w/ logrus

some cleanup and refactoring
dockerfile updates to standardize version of golang in 1 place
readme updates so developers can run docker builds locally (the azcopy requires variables that might not be available) - this does require behavior from Docker BuildKit which is docker version >=18.09
ARI-53