### PR TITLE
Set CGO_ENABLED=0 to make tests run

### DIFF
--- a/slackbot/Dockerfile
+++ b/slackbot/Dockerfile
@@ -1,20 +1,19 @@
-FROM golang:1.12.1-alpine AS golang
-
 ############################
 # STAGE 1 build Golang executable binary
 ############################
 
-FROM golang AS builder
+FROM golang:1.12.1-alpine AS builder
 ENV bin_dir=/go/bin/
-RUN apk update && apk add --no-cache openssl openssh curl bash git openssh libcurl
+#https://github.com/golang/go/issues/28065
+ENV CGO_ENABLED=0
+RUN apk update && apk add --no-cache ca-certificates openssl openssh curl bash git && update-ca-certificates 
 WORKDIR $GOPATH/src/github.com/buildit/slackbot
 ADD . $GOPATH/src/github.com/buildit/slackbot/
 RUN go get -d -v ./...
-RUN go build -v -o ${bin_dir}/bot-server.sh ./cmd/bot-server/main.go
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN mkdir /go/TestResults
 RUN go test -v ./... | go-junit-report > /go/TestResults/TestReport.xml
-
+RUN GOOS=linux GOARCH=amd64 go build -v -o ${bin_dir}/bot-server.sh ./cmd/bot-server/main.go
 
 ############################
 # STAGE 2 Upload test results to Azure
@@ -46,8 +45,7 @@ RUN azcopy \
 # STAGE 3 Build small image with only binary
 ############################
 
-FROM golang AS final
-ENV bin_dir=/go/bin/
-COPY --from=builder ${bin_dir}/bot-server.sh /go/bin/bot-server.sh
-RUN cd ${bin_dir} && ls
+FROM alpine:3.9 AS final
+RUN apk update && apk add --no-cache ca-certificates tzdata && update-ca-certificates
+COPY --from=builder /go/bin/bot-server.sh /go/bin/bot-server.sh
 ENTRYPOINT ["/go/bin/bot-server.sh"]


### PR DESCRIPTION
Issues between alpine musl and glibc in std linux distros - not entirely clear the implications
CGO deals w/ dynamic linking mostly impacted when net lib used
Also using alpine as the final image base ... golang toolchain not needed (320MB -> 20MB)
ARI-53
